### PR TITLE
feat: comments, file fn args

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -108,6 +108,11 @@ pub fn compile(ast: Vec<AstNode>) -> String {
                     vm.set_var(name, expr)
                 }
             }
+            AstNode::FnVar(vars) => {
+                for v in vars {
+                    vm.let_var(v, Expr::Lit(0));
+                }
+            }
         }
     }
     vm.halt();

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -1,7 +1,11 @@
 WHITESPACE = _{ " " }
-program = _{ SOI ~ "\n"* ~ (stmt ~ "\n"+) * ~ stmt? ~ EOI }
+COMMENT = _{ "#" ~ (!"\n" ~ ANY)* }
+
+program = _{ SOI ~ "\n"* ~ fn_header? ~ "\n"* ~ (stmt ~ "\n"+) * ~ stmt? ~ EOI }
 
 stmt = { var ~ "=" ~ expr }
+
+fn_header = { "(" ~ ((varname ~ ("," | ")"))+ | ")") ~ "\n" }
 
 char = _{ ASCII_ALPHANUMERIC | "_" }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,6 +9,7 @@ struct AshParser;
 
 #[derive(Debug, Clone)]
 pub enum AstNode {
+    FnVar(Vec<String>),
     Stmt(String, bool, Expr),
 }
 
@@ -37,6 +38,19 @@ pub fn parse(source: &str) -> Result<Vec<AstNode>, Error<Rule>> {
     let pairs = AshParser::parse(Rule::program, source)?;
     for pair in pairs {
         match pair.as_rule() {
+            Rule::fn_header => {
+                // parse the function header which includes argument
+                // if invocation started in the file no arguments
+                // should be accepted. Instead the argv function should
+                // be used
+                let pair = pair.into_inner();
+                let mut vars: Vec<String> = Vec::new();
+                for v in pair {
+                    vars.push(v.as_str().to_string());
+                }
+                // let pair.next().unwrap()
+                ast.push(FnVar(vars));
+            }
             Rule::stmt => {
                 ast.push(build_ast_from_pair(pair));
             }

--- a/src/test.ash
+++ b/src/test.ash
@@ -1,3 +1,10 @@
+# entry files may not accept arguments
+# instead argv() should be provided
+# by the implementation for the target
+# system
+#
+# accepted arguments are 0 for entry files
+(testparam)
 
 let a = 10
 let b = 100


### PR DESCRIPTION
The parser currently handles the logic to ensure the file function args are only supplied once.

e.g. preventing

```sh
(args)
()
()

let v = 10
```

This could be implemented at the compiler level instead, and would simplify the grammar.