### PR TITLE
return statements/outputs

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -89,6 +89,9 @@ impl Compiler {
                         vm.let_var(v, Expr::Lit(0));
                     }
                 }
+                AstNode::Rtrn(expr) => {
+                    vm.return_expr(expr);
+                }
             }
         }
         vm.halt();

--- a/src/compiler/vm.rs
+++ b/src/compiler/vm.rs
@@ -22,6 +22,11 @@ impl VM {
         }
     }
 
+    pub fn return_expr(&mut self, expr: Expr) {
+        self.eval(expr);
+        self.asm.push(format!("write_io 1"));
+    }
+
     pub fn let_var(&mut self, name: String, expr: Expr) {
         if self.vars.contains_key(&name) {
             panic!("var is not unique");

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -1,7 +1,7 @@
 WHITESPACE = _{ " " }
 COMMENT = _{ "#" ~ (!"\n" ~ ANY)* }
 
-program = _{ SOI ~ "\n"* ~ fn_header? ~ "\n"* ~ (stmt ~ "\n"+) * ~ stmt? ~ EOI }
+program = _{ SOI ~ "\n"* ~ fn_header? ~ "\n"* ~ (stmt ~ "\n"+) * ~ (return_stmt ~ "\n"?)? ~ EOI }
 
 stmt = { var ~ "=" ~ expr }
 
@@ -17,6 +17,8 @@ atom = { literal_dec | varname }
 let_r = { "let " }
 
 var = { let_r? ~ varname }
+
+return_stmt = { "return " ~ expr }
 
 op = _{ add | sub | mul | inv }
     add = { "+" }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,6 +11,7 @@ struct AshParser;
 pub enum AstNode {
     FnVar(Vec<String>),
     Stmt(String, bool, Expr),
+    Rtrn(Expr),
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +54,11 @@ pub fn parse(source: &str) -> Result<Vec<AstNode>, Error<Rule>> {
             }
             Rule::stmt => {
                 ast.push(build_ast_from_pair(pair));
+            }
+            Rule::return_stmt => {
+                let mut pair = pair.into_inner();
+                let next = pair.next().unwrap();
+                ast.push(Rtrn(build_expr_from_pair(next)))
             }
             _ => {}
         }

--- a/src/test.ash
+++ b/src/test.ash
@@ -10,4 +10,6 @@ let c = 1000
 
 let z = b - a + c / 2 * 4
 
-#return helloworld()
+c = a * z + c / z * z * z * z
+
+return c


### PR DESCRIPTION
Adds a `return` keyword that creates a public output with a variable. `return` may be invoked once per program and must be the last instruction.

Related TritonVM/triton-vm#307